### PR TITLE
Update style.css (fix for issue #3)

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,3 +17,7 @@
 .dokuwiki #plugin__captcha_wrapper .no {
     display: none;
 }
+
+.dokuwiki #plugin__captcha_wrapper {
+clear: left;
+}


### PR DESCRIPTION
Updated style.css, fix for Firefox/Chrome users where text boxes can't be selected/focused using the mouse. This occurs when the captcha is used within bureacracy.

Fix provided by lupo49 

https://github.com/splitbrain/dokuwiki-plugin-captcha/issues/3
