### PR TITLE
Highlighted CAPTCHA before submit button

### DIFF
--- a/action.php
+++ b/action.php
@@ -200,7 +200,7 @@ class action_plugin_captcha extends DokuWiki_Action_Plugin {
         $helper = plugin_load('helper', 'captcha');
         $out = $helper->getHTML();
 
-        // new wiki - insert after the submit button
+        // new wiki - insert before the submit button
         $event->data->insertElement($pos, $out);
     }
 

--- a/action.php
+++ b/action.php
@@ -201,7 +201,7 @@ class action_plugin_captcha extends DokuWiki_Action_Plugin {
         $out = $helper->getHTML();
 
         // new wiki - insert after the submit button
-        $event->data->insertElement($pos + 1, $out);
+        $event->data->insertElement($pos, $out);
     }
 
     /**

--- a/style.css
+++ b/style.css
@@ -32,5 +32,8 @@
 }
 
 .dokuwiki #plugin__captcha_wrapper {
-clear: left;
+    clear: left;
+    border: 1px solid __border__;
+    padding: 0.75em;
+    margin: 1em 0;
 }


### PR DESCRIPTION
CAPTCHA after submit button seems awkward, both functionally and visually.
The following images show the changes of this PR in the four forms with CAPTCHA enabled.


![registration-old](https://user-images.githubusercontent.com/29295108/27202633-b6a42498-51f8-11e7-99c6-e7ff5a6c18ee.png)
![registration-new](https://user-images.githubusercontent.com/29295108/27202646-c0fd928a-51f8-11e7-8e03-50daa00dfa36.png)


![login-old](https://user-images.githubusercontent.com/29295108/27202651-c8a9384a-51f8-11e7-85b9-56edd597313f.png)
![login-new](https://user-images.githubusercontent.com/29295108/27202659-ce332d70-51f8-11e7-8c51-b36d69a0f108.png)


![send-password-old](https://user-images.githubusercontent.com/29295108/27202665-d5f8619c-51f8-11e7-9ddf-90417653776f.png)
![send-password-new](https://user-images.githubusercontent.com/29295108/27202675-daa78948-51f8-11e7-9bb3-94889221c8b9.png)


![edit-old](https://user-images.githubusercontent.com/29295108/27202687-e739b956-51f8-11e7-9b79-6f54ff46394c.png)
![edit-new](https://user-images.githubusercontent.com/29295108/27202695-eb04d4bc-51f8-11e7-933b-343558cc4e12.png)
