### PR TITLE
added Greek language files

### DIFF
--- a/lang/el/lang.php
+++ b/lang/el/lang.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Greek language file
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ * @author Apostolos P. Tsompanopoulos <monotropos@gmail.com>
+ */
+
+$lang['testfailed']  = "Λυπούμαστε, η απάντησή σας είναι λάθος.";
+$lang['fillcaptcha'] = "Θα πρέπει να πληκτρολογήσετε όλα τα γράμματα που βλέπετε";
+$lang['fillmath']    = "Θα πρέπει να λύσετε την αριθμητική πράξη που ακολουθεί για να εγγραφείτε.<br>";
+$lang['soundlink']   = "Αν δε μπορείτε να διαβάσετε τα γράμματα στην εικόνα, κατεβάστε αυτό το αρχείο .wav για να τα ακούσετε.";
+$lang['honeypot']    = "Αφήστε κενό αυτό το πεδίο: ";

--- a/lang/el/settings.php
+++ b/lang/el/settings.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Greek language file
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ * @author Apostolos P. Tsompanopoulos <monotropos@gmail.com>
+ */
+
+$lang['mode']          = "Ποιον τύπο CAPTCHA θα χρησιμοποιήσετε;";
+$lang['mode_o_js']     = "Κείμενο (προσυμπληρωμένο με JavaScript)";
+$lang['mode_o_text']   = "Κείμενο (με μη αυτόματο τρόπο)";
+$lang['mode_o_math']   = "Αριθμητική πράξη";
+$lang['mode_o_question'] = "Προκαθορισμένη ερώτηση";
+$lang['mode_o_image']  = "Εικόνα (κακή προσβασιμότητα)";
+$lang['mode_o_audio']  = "Εικόνα+Ήχος (καλύτερη προσβασιμότητα)";
+$lang['mode_o_svg']  = "SVG (κακή προσβασιμότητα, αναγνώσιμο)";
+$lang['mode_o_svgaudio']  = "SVG+Ήχος (καλύτερη προσβασιμότητα, αναγνώσιμο)";
+$lang['mode_o_figlet'] = "Figlet ASCII σχέδιο (κακή προσβασιμότητα)";
+
+$lang['forusers']   = "Να χρησιμοποιηθεί CAPTCHA και για τους χρήστες που είναι ενεργοί;";
+$lang['loginprotect'] = "Απαιτείται το CAPTCHA για την είσοδο των χρηστών;";
+$lang['lettercount']= "Αριθμός γραμμάτων που θα χρησιμοποιηθούν (3-16). Αν αυξήσετε το πλήθος, αυξήστε ανάλογα και το πλάτος της εικόνας παρακάτω.";
+$lang['width']      = "Πλάτος της εικόνας CAPTCHA (εικονοστοιχεία)";
+$lang['height']     = "Ύψος της εικόνας CAPTCHA (εικονοστοιχεία)";
+$lang['question']   = "Ερώτηση για τον τύπο «προκαθορισμένη ερώτηση»";
+$lang['answer']     = "Απάντηση για τον τύπο «προκαθορισμένη ερώτηση»";


### PR DESCRIPTION
I added the two lang/el files with Greek translations and I would like to ask to remove the question mark from line 348 of helper.php because in Greece the question mark is ';' (instead of '?') and, in general, it is not necessary there.

Line 348 of helper.php:
$task = $num[0].(($op < 0) ? '-' : '+').$num[1].'=?';
to be:
$task = $num[0].(($op < 0) ? '-' : '+').$num[1].'= ';