### PR TITLE
Audio fix

### DIFF
--- a/wav.php
+++ b/wav.php
@@ -31,8 +31,8 @@ $wavs = array();
 $lettercount = $plugin->getConf('lettercount');
 if($lettercount > strlen($code)) $lettercount = strlen($code);
 for($i = 0; $i < $lettercount; $i++) {
-    $file = $lc.$code{$i}.'.wav';
-    if(!@file_exists($file)) $file = $en.$code{$i}.'.wav';
+    $file = $lc.$code[$i].'.wav';
+    if(!@file_exists($file)) $file = $en.$code[$i].'.wav';
     $wavs[] = $file;
 }
 


### PR DESCRIPTION
Audio link doesn't work in PHP 7.4.
File `wav.php` uses curly braces (deprecated) to access an array.