### PR TITLE
support new Form and Utf8\PhpString class methods

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -1,4 +1,7 @@
 <?php
+
+use dokuwiki\Utf8;
+
 /**
  * Class helper_plugin_captcha
  *
@@ -154,11 +157,19 @@ class helper_plugin_captcha extends DokuWiki_Plugin
             $code = $this->_generateCAPTCHA($this->_fixedIdent(), $rand);
         }
 
+        // set callable that converts string to lowercase
+        if (method_exists(Utf8\PhpString::class, 'strtolower')) {
+            $toLower = [Utf8\PhpString::class, 'strtolower'];
+        } else {
+            // fallback deprecated utf8_strtolower since 2019-06-09
+            $toLower = 'utf8_strtolower';
+        }
+
         // compare values
         if (!$field_sec ||
             !$field_in ||
             $rand === false ||
-            utf8_strtolower($field_in) != utf8_strtolower($code) ||
+            $toLower($field_in) != $toLower($code) ||
             trim($field_hp) !== '' ||
             !$this->retrieveCaptchaCookie($this->_fixedIdent(), $rand)
         ) {

--- a/helper.php
+++ b/helper.php
@@ -285,13 +285,13 @@ class helper_plugin_captcha extends DokuWiki_Plugin
 
         $len = strlen($text);
         for ($i = 0; $i < $len - 1; $i++) {
-            $new .= $text{$i};
+            $new .= $text[$i];
 
-            if (!is_numeric($text{$i + 1})) {
+            if (!is_numeric($text[$i + 1])) {
                 $new .= $spaces[array_rand($spaces)];
             }
         }
-        $new .= $text{$len - 1};
+        $new .= $text[$len - 1];
         return $new;
     }
 


### PR DESCRIPTION
This PR will make the Captcha plugin compatible with DokuWiki snapshot 2020-10-13 or later that [#3198](https://github.com/splitbrain/dokuwiki/pull/3198) merged.
- support new events: `FORM_EDIT_OUTPUT`, `FORM_REGISTER_OUTPUT`, `FORM_RESENDPWD_OUTPUT`
- use `Utf8\PhpString::strtolower()` instead of deprecated `utf8_strtolower()` function

This PR will fix curly brace for string offset deprecated in PHP 7.4, see also #109 that fixes same issue in wav.php file