### PR TITLE
Make audio link processing more specific

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -83,7 +83,7 @@ class helper_plugin_captcha extends DokuWiki_Plugin {
                 $out .= $this->_svgCAPTCHA($code);
                 $out .= '</span>';
                 $out .= '<a href="'.DOKU_BASE.'lib/plugins/captcha/wav.php?secret='.rawurlencode($secret).'&amp;id='.$ID.'"'.
-                    ' class="JSnocheck" title="'.$this->getLang('soundlink').'">';
+                    ' class="JSnocheck audiolink" title="'.$this->getLang('soundlink').'">';
                 $out .= '<img src="'.DOKU_BASE.'lib/plugins/captcha/sound.png" width="16" height="16"'.
                     ' alt="'.$this->getLang('soundlink').'" /></a>';
                 break;
@@ -95,7 +95,7 @@ class helper_plugin_captcha extends DokuWiki_Plugin {
                 $out .= '<img src="'.DOKU_BASE.'lib/plugins/captcha/img.php?secret='.rawurlencode($secret).'&amp;id='.$ID.'" '.
                     ' width="'.$this->getConf('width').'" height="'.$this->getConf('height').'" alt="" /> ';
                 $out .= '<a href="'.DOKU_BASE.'lib/plugins/captcha/wav.php?secret='.rawurlencode($secret).'&amp;id='.$ID.'"'.
-                    ' class="JSnocheck" title="'.$this->getLang('soundlink').'">';
+                    ' class="JSnocheck audiolink" title="'.$this->getLang('soundlink').'">';
                 $out .= '<img src="'.DOKU_BASE.'lib/plugins/captcha/sound.png" width="16" height="16"'.
                     ' alt="'.$this->getLang('soundlink').'" /></a>';
                 break;

--- a/script.js
+++ b/script.js
@@ -16,7 +16,7 @@ jQuery(function () {
     /**
      * Add a HTML5 player for the audio version of the CAPTCHA
      */
-    var $audiolink = $wrap.find('a');
+    var $audiolink = $wrap.find('a.audiolink');
     if($audiolink.length) {
         var audio = document.createElement('audio');
         if(audio) {


### PR DESCRIPTION
In the registration form, I've picked "question" and added HTML to the question, to link to the answer (because the question is kind of arcane). However, clicking the link does nothing. Inspecting the page, I found JS code that tries to extract the link to the audio snipped from an anchor tag, and then attaches a hander to the anchor that starts playing the audio and stops event processing.

This change makes the JS code more specific.