### PR TITLE
Update helper.php: utf8_strtolower() is deprecated warning

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -150,7 +150,7 @@ class helper_plugin_captcha extends DokuWiki_Plugin
         if (!$field_sec ||
             !$field_in ||
             $rand === false ||
-            utf8_strtolower($field_in) != utf8_strtolower($code) ||
+            strtolower($field_in) != strtolower($code) ||
             trim($field_hp) !== '' ||
             !$this->retrieveCaptchaCookie($this->_fixedIdent(), $rand)
         ) {

--- a/helper.php
+++ b/helper.php
@@ -150,7 +150,7 @@ class helper_plugin_captcha extends DokuWiki_Plugin
         if (!$field_sec ||
             !$field_in ||
             $rand === false ||
-            strtolower($field_in) != strtolower($code) ||
+            \dokuwiki\Utf8\PhpString::strtolower($field_in) != \dokuwiki\Utf8\PhpString::strtolower($code) ||
             trim($field_hp) !== '' ||
             !$this->retrieveCaptchaCookie($this->_fixedIdent(), $rand)
         ) {


### PR DESCRIPTION
Fix deprecation warning:

```
utf8_strtolower() is deprecated. It was called from helper_plugin_captcha::check() in /lib/plugins/captcha/helper.php:153 dokuwiki\Utf8\PhpString::strtolower() should be used instead!
```